### PR TITLE
update: use rustls in reqwest(build-dep)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ schemafy = "0.6.0"
 serde_variant = "0.1.1"
 
 [build-dependencies]
-reqwest = { version = "0.11.8", features = ["blocking"] }
+reqwest = { version = "0.11.8", default-features = false, features = ["blocking", "rustls-tls"] }
 
 [dev-dependencies]
 prettydiff = "0.5.1"


### PR DESCRIPTION
`openssl-sys`で `minecraft-whitelist-validator`のシングルバイナリビルドがコケるので
https://github.com/sksat/minecraft-whitelist-validator/runs/4687095572?check_suite_focus=true