### PR TITLE
Update nightly rust version in check docs.rs build job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1.0.7
         with:
-          toolchain: nightly-2021-12-30
+          toolchain: nightly-2024-06-23
           override: true
 
       - name: check cargo version


### PR DESCRIPTION
- docs.rs のビルドチェック用の nightly Rust のバージョンを更新
  - https://docs.rs/about/builds
- 今コケてる